### PR TITLE
Changes to match riot/game-1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ _cgo_export.*
 _testmain.go
 
 *.exe
-
-# goriot specific
-goriot.test


### PR DESCRIPTION
Implemented changes introduced in game-1.3. Names could probably be better in some places (NumDeaths, Num*) but kept it the same as API reference as it was easiest.

Tests passed except `TestLeagueBySummoner` but the underlying call was failing on Riot's site as well (404 in both cases).

Related to #13 
