### PR TITLE
League 2.3 - Challenger and single entry by summoner

### DIFF
--- a/goriot.go
+++ b/goriot.go
@@ -28,12 +28,12 @@ var (
 	SEASON3 = "SEASON3"
 	//SEASON4 is the string of "SEASON4". Used to help prevent typos
 	SEASON4 = "SEASON4"
-    //Ranked Solo 5s
-    RANKED_SOLO_5x5 = "RANKED_SOLO_5x5"
-    //Ranked Team 3s
-    RANKED_TEAM_3x3 = "RANKED_TEAM_3x3"
-    //Ranked Team 5s
-    RANKED_TEAM_5x5 = "RANKED_TEAM_5x5"
+	//Ranked Solo 5s
+	RANKED_SOLO_5x5 = "RANKED_SOLO_5x5"
+	//Ranked Team 3s
+	RANKED_TEAM_3x3 = "RANKED_TEAM_3x3"
+	//Ranked Team 5s
+	RANKED_TEAM_5x5 = "RANKED_TEAM_5x5"
 	//ErrAPIKeyNotSet is the error returned when no global API key has been set
 	ErrAPIKeyNotSet = errors.New("goriot: API key has not been set. If you need a key visit https://developer.riotgames.com/")
 	smallRateChan   rateChan

--- a/goriot_test.go
+++ b/goriot_test.go
@@ -44,12 +44,12 @@ func TestLeagueBySummoner(t *testing.T) {
 }
 
 func TestLeagueByChallenger(t *testing.T) {
-    SetAPIKey(personalkey)
-    _, err := LeagueByChallenger(NA, RANKED_SOLO_5x5)
-    if err != nil {
-        t.Error(err.Error())
-    }
-    fmt.Println("done")
+	SetAPIKey(personalkey)
+	_, err := LeagueByChallenger(NA, RANKED_SOLO_5x5)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	fmt.Println("done")
 }
 
 func TestLeagueEntryBySummoner(t *testing.T) {

--- a/league.go
+++ b/league.go
@@ -80,21 +80,21 @@ func LeagueEntryBySummoner(region string, summonerID int64) (entry []LeagueItem,
 //It returns a League and any erros that occured from the server
 //The global API key must be set before use
 func LeagueByChallenger(region string, queueType string) (league League, err error) {
-    if !IsKeySet() {
-        return league, ErrAPIKeyNotSet
-    }
-    args := fmt.Sprintf(
-        "type=%v&api_key=%v",
-        queueType,
-        apikey)
-    url := fmt.Sprintf(
-        "%v/lol/%v/v2.3/league/challenger?%v",
-        BaseURL,
-        region,
-        args)
-    err = requestAndUnmarshal(url, &league)
-    if err != nil {
-        return
-    }
-    return league, err
+	if !IsKeySet() {
+		return league, ErrAPIKeyNotSet
+	}
+	args := fmt.Sprintf(
+		"type=%v&api_key=%v",
+		queueType,
+		apikey)
+	url := fmt.Sprintf(
+		"%v/lol/%v/v2.3/league/challenger?%v",
+		BaseURL,
+		region,
+		args)
+	err = requestAndUnmarshal(url, &league)
+	if err != nil {
+		return
+	}
+	return league, err
 }


### PR DESCRIPTION
Added functions for the two new endpoints:
- by-summoner/{summonerid}/entry - this endpoint displays only the entry for the given summoner. The existing endpoint shows entries for every summoner in the same league
- challenger - challenger tier data for Ranked SoloQ 5s, Ranked Team 3s, and Ranked Team 5s

I have added tests for the new functions as well as some variables to prevent typos
