### PR TITLE
Updated League to version 2.5

### DIFF
--- a/goriot_test.go
+++ b/goriot_test.go
@@ -70,6 +70,24 @@ func TestLeagueEntryBySummoner(t *testing.T) {
 	fmt.Println("done")
 }
 
+func TestLeagueByTeam(t *testing.T) {
+	SetAPIKey(personalkey)
+	_, err := LeagueByTeam(NA, "TEAM-9179f610-7a48-11e3-b350-782bcb4d0bb2")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	fmt.Println("done")
+}
+
+func TestLeagueEntryByTeam(t *testing.T) {
+	SetAPIKey(personalkey)
+	_, err := LeagueEntryByTeam(NA, "TEAM-9179f610-7a48-11e3-b350-782bcb4d0bb2")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	fmt.Println("done")
+}
+
 func TestStatSummariesBySummoner(t *testing.T) {
 	SetAPIKey(personalkey)
 	_, err := StatSummariesBySummoner(NA, 2112, SEASON3)

--- a/league.go
+++ b/league.go
@@ -1,7 +1,9 @@
 package goriot
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 )
 
 //League represents a League of Legends league
@@ -15,66 +17,189 @@ type League struct {
 
 //LeagueItem is an entry in a League. It represents a player or team
 type LeagueItem struct {
+	Division         string     `json:"division"`
 	IsFreshBlood     bool       `json:"isFreshBlood"`
 	IsHotStreak      bool       `json:"isHotStreak"`
 	IsInactive       bool       `json:"isInactive"`
 	IsVeteran        bool       `json:"isVeteran"`
-	LastPlayed       int64      `json:"lastPlayed"`
-	LeagueName       string     `json:"leagueName"`
 	LeaguePoints     int        `json:"leaguePoints"`
 	MiniSeries       MiniSeries `json:"miniSeries"`
 	PlayerOrTeamID   string     `json:"playerOrTeamId"`
 	PlayerOrTeamName string     `json:"playerOrTeamName"`
-	QueueType        string     `json:"queueType"`
-	Rank             string     `json:"rank"`
-	Tier             string     `json:"tier"`
 	Wins             int        `json:"wins"`
 }
 
 //MiniSeries shows if a player is in their Series and how far they are within it
 type MiniSeries struct {
-	Losses               int    `json:"losses"`
-	Progress             string `json:"progress"`
-	Target               int    `json:"target"`
-	TimeLeftToPlayMillis int64  `json:"timeLeftToPlayMillis"`
-	Wins                 int    `json:"wins"`
+	Losses   int    `json:"losses"`
+	Progress string `json:"progress"`
+	Target   int    `json:"target"`
+	Wins     int    `json:"wins"`
 }
 
-//LeagueBySummoner retrieves the league of the supplied summonerID from Riot Games API.
+//LeagueBySummoner retrieves the league of the supplied summonerID(s) from Riot Games API.
 //It returns a League and any errors that occured from the server
 //The global API key must be set before use
-func LeagueBySummoner(region string, summonerID int64) (league []League, err error) {
+func LeagueBySummoner(region string, summonerID ...int64) (leagues map[int64][]League, err error) {
 	if !IsKeySet() {
-		return league, ErrAPIKeyNotSet
+		return leagues, ErrAPIKeyNotSet
 	}
+
+	// this API method only allows 10 summoners
+	if len(summonerID) > 10 {
+		return leagues, errors.New("Too many summoners requested. Limit is 10")
+	}
+
+	leagues = make(map[int64][]League)
+	preLeagues := make(map[string][]League)
+
+	// Turn summoner array into string
+	summonerIDstr, err := createSummonerIDString(summonerID)
+	if err != nil {
+		return leagues, err
+	}
+
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v2.3/league/by-summoner/%d?%v", region, BaseURL, region, summonerID, args)
-	err = requestAndUnmarshal(url, &league)
+	url := fmt.Sprintf(
+		"https://%v.%v/lol/%v/v2.5/league/by-summoner/%v?%v",
+		region,
+		BaseURL,
+		region,
+		summonerIDstr,
+		args)
+	err = requestAndUnmarshal(url, &preLeagues)
 	if err != nil {
 		return
 	}
-	return league, err
+
+	for k, v := range preLeagues {
+		id, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		leagues[id] = v
+	}
+
+	return leagues, err
 }
 
 //LeagueEntryBySummoner retrieves the league entry of the supplied summonerID.
 //The difference from LeagueBySummoner is that LeagueEntryBySummoner only returns data for the given summonerID vs everyone in that summoner's league
-func LeagueEntryBySummoner(region string, summonerID int64) (entry []LeagueItem, err error) {
+func LeagueEntryBySummoner(region string, summonerID ...int64) (leagues map[int64][]League, err error) {
 	if !IsKeySet() {
-		return entry, ErrAPIKeyNotSet
+		return leagues, ErrAPIKeyNotSet
 	}
+
+	// this API method only allows 10 summoners
+	if len(summonerID) > 10 {
+		return leagues, errors.New("Too many summoners requested. Limit is 10")
+	}
+
+	leagues = make(map[int64][]League)
+	preLeagues := make(map[string][]League)
+
+	// Turn summoner array into string
+	summonerIDstr, err := createSummonerIDString(summonerID)
+	if err != nil {
+		return leagues, err
+	}
+
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(
-		"https://%v.%v/lol/%v/v2.3/league/by-summoner/%d/entry?%v",
+		"https://%v.%v/lol/%v/v2.5/league/by-summoner/%v/entry?%v",
 		region,
 		BaseURL,
 		region,
-		summonerID,
+		summonerIDstr,
 		args)
-	err = requestAndUnmarshal(url, &entry)
+	err = requestAndUnmarshal(url, &preLeagues)
 	if err != nil {
-		return
+		return nil, err
 	}
-	return entry, err
+
+	for k, v := range preLeagues {
+		id, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		leagues[id] = v
+	}
+
+	return leagues, err
+}
+
+// LeagueByTeam retrieves all leagues for passed in Team(s)
+// It returns a map of TeamID to slice of League and any errors
+// The global API key must be set before use
+func LeagueByTeam(region string, teamID ...string) (leagues map[string][]League, err error) {
+
+	if !IsKeySet() {
+		return leagues, ErrAPIKeyNotSet
+	}
+
+	if len(teamID) > 10 {
+		return leagues, errors.New("Too many teams requested. Limit is 10")
+	}
+
+	leagues = make(map[string][]League)
+
+	teamIDstr, err := createTeamIDString(teamID)
+	if err != nil {
+		return leagues, err
+	}
+
+	args := "api_key=" + apikey
+	url := fmt.Sprintf(
+		"https://%v.%v/lol/%v/v2.5/league/by-team/%v?%v",
+		region,
+		BaseURL,
+		region,
+		teamIDstr,
+		args)
+	err = requestAndUnmarshal(url, &leagues)
+	if err != nil {
+		return leagues, err
+	}
+
+	return leagues, err
+}
+
+// LeagueEntryByTeam retrieves all entries for a Team
+// It returns a League and any errors that occured from the server
+// The global API key must be set before use
+func LeagueEntryByTeam(region string, teamID ...string) (leagues map[string][]League, err error) {
+
+	if !IsKeySet() {
+		return leagues, ErrAPIKeyNotSet
+	}
+
+	if len(teamID) > 10 {
+		return leagues, errors.New("Too many teams requested. Limit is 10")
+	}
+
+	leagues = make(map[string][]League)
+
+	teamIDstr, err := createTeamIDString(teamID)
+	if err != nil {
+		return leagues, err
+	}
+
+	args := "api_key=" + apikey
+	url := fmt.Sprintf(
+		"https://%v.%v/lol/%v/v2.5/league/by-team/%v/entry?%v",
+		region,
+		BaseURL,
+		region,
+		teamIDstr,
+		args)
+	err = requestAndUnmarshal(url, &leagues)
+	if err != nil {
+		return leagues, err
+	}
+
+	return leagues, err
 }
 
 //LeagueByChallenger retrieves all the league entries for the Challenger group
@@ -89,7 +214,7 @@ func LeagueByChallenger(region string, queueType string) (league League, err err
 		queueType,
 		apikey)
 	url := fmt.Sprintf(
-		"https://%v.%v/lol/%v/v2.3/league/challenger?%v",
+		"https://%v.%v/lol/%v/v2.5/league/challenger?%v",
 		region,
 		BaseURL,
 		region,

--- a/team.go
+++ b/team.go
@@ -1,6 +1,7 @@
 package goriot
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -87,5 +88,21 @@ func TeamBySummonerID(region string, summonerID int64) (team []Team, err error) 
 	if err != nil {
 		return
 	}
+	return
+}
+
+func createTeamIDString(teamID []string) (teamIDstr string, err error) {
+
+	if len(teamID) > 10 {
+		return teamIDstr, errors.New("A Maximum of 10 TeamIDs are allowed")
+	}
+
+	for k, v := range teamID {
+		teamIDstr += v
+		if k != len(teamID)-1 {
+			teamIDstr += ","
+		}
+	}
+
 	return
 }


### PR DESCRIPTION
The new version removes several fields from the `LeagueItem` struct
that already appear in `League`. It also has new capabilities including
- support for Teams
- selecting up to 10 Summoners or Teams

With the addition of looking at Leagues by Team, I've added a function
that concatenates a slice of TeamIDs to a comma seperated string. It
works identically to `createSummonerIDString`.

Tests for the new Team interface in `league.go` have been added.
