### PR TITLE
Updated Team to 2.4

### DIFF
--- a/goriot_test.go
+++ b/goriot_test.go
@@ -135,7 +135,16 @@ func TestSummonerNamesByID(t *testing.T) {
 
 func TestTeamBySummonerID(t *testing.T) {
 	SetAPIKey(personalkey)
-	_, err := TeamBySummonerID(NA, 2112)
+	_, err := TeamBySummonerID(NA, 24199871)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	fmt.Println("done")
+}
+
+func TestTeamByTeamID(t *testing.T) {
+	SetAPIKey(personalkey)
+	_, err := TeamByTeamID(NA, "TEAM-9179f610-7a48-11e3-b350-782bcb4d0bb2")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/team.go
+++ b/team.go
@@ -2,6 +2,8 @@ package goriot
 
 import (
 	"fmt"
+	"errors"
+	"strconv"
 )
 
 //Team is a League of Legends Ranked Team
@@ -12,24 +14,24 @@ type Team struct {
 	LastJoinDate                  int64                 `json:"lastJoinDate"`
 	LastJoinedRankedTeamQueueDate int64                 `json:"lastJoinedRankedTeamQueueDate"`
 	MatchHistory                  []MatchHistorySummary `json:"matchHistory"`
-	MessageOfDay                  MessageOfDay          `json:"messageOfDay"`
 	ModifyDate                    int64                 `json:"modifyDate"`
 	Name                          string                `json:"name"`
 	Roster                        Roster                `json:"roster"`
 	SecondLastJoinDate            int64                 `json:"secondLastJoinDate"`
 	Status                        string                `json:"status"`
 	Tag                           string                `json:"tag"`
-	TeamStatSummary               TeamStatSummary       `json:"teamStatSummary"`
+	TeamStatDetails               []TeamStatDetail      `json:"teamStatDetails"`
 	ThirdJoinDate                 int64                 `json:"thirdLastJoinDate"`
 }
 
 //MatchHistorySummary is a summary of a matches played by a Team
 type MatchHistorySummary struct {
 	Assists           int    `json:"assists"`
+	Date              int64  `json:"date"`
 	Deaths            int    `json:"deaths"`
 	GameID            int64  `json:"gameId"`
 	GameMode          string `json:"gameMode"`
-	Invalid           bool   `json:"inalid"`
+	Invalid           bool   `json:"invalid"`
 	Kills             int    `json:"kills"`
 	MapID             int    `json:"mapId"`
 	OpposingTeamKills int    `json:"opposingTeamKills"`
@@ -37,23 +39,10 @@ type MatchHistorySummary struct {
 	Win               bool   `json:"win"`
 }
 
-//MessageOfDay is a message of the day for a ranked team
-type MessageOfDay struct {
-	CreateDate int64  `json:"createDate"`
-	Message    string `json:"message"`
-	Version    int    `json:"version"`
-}
-
 //Roster represents the roster of a League of Legends ranked team
 type Roster struct {
 	MemberList []TeamMemberInfo `json:"memberList"`
 	OwnerID    int64            `json:"ownerId"`
-}
-
-//TeamStatSummary is a summary of the statistics for a ranked team
-type TeamStatSummary struct {
-	FullID          string           `json:"fullId"`
-	TeamStatDetails []TeamStatDetail `json:"teamStatDetails"`
 }
 
 //TeamMemberInfo is the individual information for a player on a ranked team
@@ -67,7 +56,6 @@ type TeamMemberInfo struct {
 //TeamStatDetail is the statistics for a ranked team
 type TeamStatDetail struct {
 	AverageGamesPlayed int    `json:"averageGamesPlayed"`
-	FullID             string `json:"fullId"`
 	Losses             int    `json:"losses"`
 	TeamStatType       string `json:"teamStatType"`
 	Wins               int    `json:"wins"`
@@ -76,16 +64,91 @@ type TeamStatDetail struct {
 //TeamBySummonerID retrieves a summoner's assosiated teams from Riot Games API.
 //It returns an array of Team and any errors that occured from the server
 //The global API key must be set before use
-func TeamBySummonerID(region string, summonerID int64) (team []Team, err error) {
+func TeamBySummonerID(region string, summonerID ...int64) (teams map[int64][]Team, err error) {
 	if !IsKeySet() {
-		return team, ErrAPIKeyNotSet
+		return nil, ErrAPIKeyNotSet
 	}
-	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v2.2/team/by-summoner/%d?%v", region, BaseURL, region, summonerID, args)
 
-	err = requestAndUnmarshal(url, &team)
+	// Only 10 summoners are currently allowed to be looked up
+	if len(summonerID) > 10 {
+		return nil, errors.New("TeamBySummoner only allows 10 summoner IDs")
+	}
+
+	teams = make(map[int64][]Team)
+	preTeams := make(map[string][]Team)
+
+	summonerIdStr, err := createSummonerIDString(summonerID)
 	if err != nil {
-		return
+		return nil, err
+	}
+
+	args := "api_key=" + apikey
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v2.4/team/by-summoner/%v?%v",
+		region, BaseURL, region, summonerIdStr, args)
+
+	err = requestAndUnmarshal(url, &preTeams)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert summoner IDs to int64
+	for k, v := range preTeams {
+		id, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		teams[id] = v
+	}
+
+	return teams, nil
+}
+
+// Search for Team information using Team ID
+// Returns Team match history and information or errors from server
+// Global API key must be set prior to use
+func TeamByTeamID(region string, teamID ...string) (teams map[string]Team, err error) {
+
+	if !IsKeySet() {
+		return nil, ErrAPIKeyNotSet
+	}
+
+	teams = make(map[string]Team)
+
+	teamIdStr, err := createTeamIDString(teamID)
+	if err != nil {
+		return nil, err
+	}
+
+	args := "api_key=" + apikey
+	url := fmt.Sprintf(
+		"https://%v.%v/lol/%v/v2.4/team/%v?%v",
+		region,
+		BaseURL,
+		region,
+		teamIdStr,
+		args)
+
+	err = requestAndUnmarshal(url, &teams)
+	if err != nil {
+		return nil, err
+	}
+
+	return teams, nil
+}
+
+// Creates a string of comma seperated Team IDs from
+// a slice of Team IDs
+// There is currently a hard limit of 10 Teams
+func createTeamIDString(teamID []string) (teamIDstr string, err error) {
+	if len(teamID) > 10 {
+		return teamIDstr, errors.New("A Maximum of 10 TeamIDs are allowed")
+	}
+	for k, v := range teamID {
+		teamIDstr += v
+		if k != len(teamID)-1 {
+			teamIDstr += ","
+		}
 	}
 	return
 }


### PR DESCRIPTION
The latest version of the Team API allows a client
to request up to 10 summoners at a time. There is also the ability
to search for a team based on their TeamID or up to 10 Teams.

I've also added a function to create comma seperated strings
based on TeamIDs. This is very similar to `createSummonerIDString`
except that it takes a `[]string` as an argument versus a `[]int64`.

A test has been added for `TeamByTeamID`.
