### PR TITLE
Switched to the new way of creating URL parameter strings

### DIFF
--- a/league.go
+++ b/league.go
@@ -52,12 +52,7 @@ func LeagueBySummoner(region string, summonerID ...int64) (leagues map[int64][]L
 
 	leagues = make(map[int64][]League)
 	preLeagues := make(map[string][]League)
-
-	// Turn summoner array into string
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return leagues, err
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(
@@ -98,12 +93,7 @@ func LeagueEntryBySummoner(region string, summonerID ...int64) (leagues map[int6
 
 	leagues = make(map[int64][]League)
 	preLeagues := make(map[string][]League)
-
-	// Turn summoner array into string
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return leagues, err
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(
@@ -144,11 +134,7 @@ func LeagueByTeam(region string, teamID ...string) (leagues map[string][]League,
 	}
 
 	leagues = make(map[string][]League)
-
-	teamIDstr, err := createTeamIDString(teamID)
-	if err != nil {
-		return leagues, err
-	}
+	teamIDstr := strURLParameter(teamID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(
@@ -180,11 +166,7 @@ func LeagueEntryByTeam(region string, teamID ...string) (leagues map[string][]Le
 	}
 
 	leagues = make(map[string][]League)
-
-	teamIDstr, err := createTeamIDString(teamID)
-	if err != nil {
-		return leagues, err
-	}
+	teamIDstr := strURLParameter(teamID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(

--- a/matchhistory.go
+++ b/matchhistory.go
@@ -35,23 +35,19 @@ func MatchHistoryBySummonerID(
 	}
 
 	// create a filter for specific champions
-	var championIDStr string = intURLParameter(championIDs).String()
+	championIDStr := intURLParameter(championIDs).String()
 
 	// check to see if specific queues are being filtered
-	var rankedQueuesStr string = strURLParameter(rankedQueues).String()
+	rankedQueuesStr := strURLParameter(rankedQueues).String()
 
 	// check for indexing
-	var beginIndexStr string
-	if beginIndex <= -1 {
-		beginIndexStr = ""
-	} else {
+	beginIndexStr := ""
+	if beginIndex > -1 {
 		beginIndexStr = strconv.Itoa(beginIndex)
 	}
 
-	var endIndexStr string
-	if endIndex <= -1 {
-		endIndexStr = ""
-	} else {
+	endIndexStr := ""
+	if endIndex > -1 {
 		endIndexStr = strconv.Itoa(endIndex)
 	}
 

--- a/summoner.go
+++ b/summoner.go
@@ -63,10 +63,8 @@ func MasteriesBySummoner(region string, summonerID ...int64) (masteries map[int6
 	}
 	masteries = make(map[int64][]MasteryPage)
 	var pages map[string]masteryBook
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
+
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/masteries?%v", region, BaseURL, region, summonerIDstr, args)
 	err = requestAndUnmarshal(url, &pages)
@@ -92,10 +90,8 @@ func RunesBySummoner(region string, summonerID ...int64) (runes map[int64][]Rune
 	}
 	runes = make(map[int64][]RunePage)
 	var pages map[string]runeBook
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
+
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/runes?%v", region, BaseURL, region, summonerIDstr, args)
 
@@ -122,7 +118,7 @@ func SummonerByName(region string, name ...string) (summoners map[string]Summone
 	if !IsKeySet() {
 		return summoners, ErrAPIKeyNotSet
 	}
-	names := strings.Join(name, ", ")
+	names := strURLParameter(name).String()
 	summoners = make(map[string]Summoner)
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/by-name/%v?%v", region, BaseURL, region, names, args)
@@ -143,10 +139,7 @@ func SummonerByID(region string, summonerID ...int64) (summoners map[int64]Summo
 
 	var summonersString map[string]Summoner
 	summoners = make(map[int64]Summoner)
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v?%v", region, BaseURL, region, summonerIDstr, args)
@@ -174,10 +167,8 @@ func SummonerNamesByID(region string, summonerID ...int64) (summoners map[int64]
 	}
 	var summonerNames map[string]string
 	summoners = make(map[int64]string)
-	summonerIDstr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return
-	}
+	summonerIDstr := intURLParameter(summonerID).String()
+
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/name?%v", region, BaseURL, region, summonerIDstr, args)
 

--- a/team.go
+++ b/team.go
@@ -76,11 +76,7 @@ func TeamBySummonerID(region string, summonerID ...int64) (teams map[int64][]Tea
 
 	teams = make(map[int64][]Team)
 	preTeams := make(map[string][]Team)
-
-	summonerIdStr, err := createSummonerIDString(summonerID)
-	if err != nil {
-		return nil, err
-	}
+	summonerIdStr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v2.4/team/by-summoner/%v?%v",
@@ -114,11 +110,7 @@ func TeamByTeamID(region string, teamID ...string) (teams map[string]Team, err e
 	}
 
 	teams = make(map[string]Team)
-
-	teamIdStr, err := createTeamIDString(teamID)
-	if err != nil {
-		return nil, err
-	}
+	teamIdStr := strURLParameter(teamID).String()
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf(


### PR DESCRIPTION
In the last major feature, Match and Match History, we create a new
way of building URL parameters for lists. I've switched all the methods
to use this new way, except for `game.go` as it is going away. This new
method was discussed in issue #36.
