### PR TITLE
add two official observer endpoints

### DIFF
--- a/champion.go
+++ b/champion.go
@@ -32,7 +32,7 @@ func ChampionList(region string, freetoplay bool) (champions []Champion, err err
 		args = "freeToPlay=true&"
 	}
 	args += "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.2/champion?%v", region, BaseURL, region, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.2/champion?%v", region, BaseAPIURL, region, args)
 	err = requestAndUnmarshal(url, &champs)
 	if err != nil {
 		return
@@ -50,7 +50,7 @@ func ChampionByID(region string, id int) (champion Champion, err error) {
 	}
 	var args string
 	args += "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.2/champion/%d?%v", region, BaseURL, region, id, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.2/champion/%d?%v", region, BaseAPIURL, region, id, args)
 	err = requestAndUnmarshal(url, &champion)
 	if err != nil {
 		return

--- a/featured.go
+++ b/featured.go
@@ -4,6 +4,21 @@ import (
 	"fmt"
 )
 
+var (
+	RegionToPlatformId = map[string]string{
+		"br":   "BR1",
+		"eune": "EUN1",
+		"euw":  "EUW1",
+		"kr":   "KR",
+		"lan":  "LA1",
+		"las":  "LA2",
+		"na":   "NA1",
+		"oce":  "OC1",
+		"ru":   "RU",
+		"tr":   "TR1",
+	}
+)
+
 type FeaturedGame struct {
 	GameID            int           `json:"gameId"`
 	MapID             int           `json:"mapId"`
@@ -64,7 +79,7 @@ func FeaturedGameBySummonerID(region, summonerId string) (FeaturedGame, error) {
 		"https://%v.%v/consumer/getSpectatorGameInfo/%v/%v?%v",
 		region,
 		BaseObserverURL,
-		region,
+		RegionToPlatformId[region],
 		summonerId,
 		args,
 	)

--- a/featured.go
+++ b/featured.go
@@ -1,0 +1,77 @@
+package goriot
+
+import (
+	"fmt"
+)
+
+type FeaturedGame struct {
+	GameID            int           `json:"gameId"`
+	MapID             int           `json:"mapId"`
+	GameMode          string        `json:"gameMode"`
+	GameType          string        `json:"gameType"`
+	GameQueueConfigID int           `json:"gameQueueConfigId"`
+	Participants      []Participant `json:"participants"`
+	Observers         struct {
+		EncryptionKey string `json:"encryptionKey"`
+	} `json:"observers"`
+	PlatformID      string `json:"platformId"`
+	BannedChampions []struct {
+		ChampionID int `json:"championId"`
+		TeamID     int `json:"teamId"`
+		PickTurn   int `json:"pickTurn"`
+	} `json:"bannedChampions"`
+	GameStartTime int64 `json:"gameStartTime"`
+	GameLength    int   `json:"gameLength"`
+}
+
+type Games struct {
+	ClientRefreshInterval int64          `json:"clientRefreshInterval"`
+	GameList              []FeaturedGame `json:"gameList"`
+}
+
+// FeaturedGames requests a list of FeaturedGames from Riot
+// API key needs to be set prior to use
+func FeaturedGames(region string) ([]FeaturedGame, error) {
+	if !IsKeySet() {
+		return nil, ErrAPIKeyNotSet
+	}
+
+	var games Games
+	args := "api_key=" + apikey
+	url := fmt.Sprintf(
+		"https://%v.%v/featured?%v",
+		region,
+		BaseObserverURL,
+		args)
+
+	if err := requestAndUnmarshal(url, &games); err != nil {
+		return nil, err
+	}
+
+	return games.GameList, nil
+}
+
+// FeaturedGameBySummonerID requests a FeaturedGame from Riot
+// API key needs to be set prior to use
+func FeaturedGameBySummonerID(region, summonerId string) (FeaturedGame, error) {
+	if !IsKeySet() {
+		return FeaturedGame{}, ErrAPIKeyNotSet
+	}
+
+	var game FeaturedGame
+	args := "api_key=" + apikey
+	url := fmt.Sprintf(
+		"https://%v.%v/consumer/getSpectatorGameInfo/%v/%v?%v",
+		region,
+		BaseObserverURL,
+		region,
+		summonerId,
+		args,
+	)
+
+	if err := requestAndUnmarshal(url, &game); err != nil {
+		return FeaturedGame{}, err
+	}
+
+	return game, nil
+}

--- a/game.go
+++ b/game.go
@@ -123,7 +123,7 @@ func RecentGameBySummoner(region string, summonerID int64) (games []Game, err er
 		return games, ErrAPIKeyNotSet
 	}
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/game/by-summoner/%d/recent?%v", region, BaseURL, region, summonerID, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/game/by-summoner/%d/recent?%v", region, BaseAPIURL, region, summonerID, args)
 	err = requestAndUnmarshal(url, &gameslist)
 	if err != nil {
 		return

--- a/goriot.go
+++ b/goriot.go
@@ -17,7 +17,11 @@ import (
 var (
 	apikey string
 	//BaseURL is the base of the url used by Riot's API service
-	BaseURL = "api.pvp.net/api"
+	BaseURL = "api.pvp.net"
+	//BaseURL is the base of the url used by Riot's API service
+	BaseAPIURL = BaseURL + "/api"
+	//BaseURL is the base of the url used by Riot's API service
+	BaseObserverURL = BaseURL + "/observer-mode/rest"
 	//BR represents the string for the Brazilian League of Legends Servers,
 	//only used as a helper to prevent typos
 	BR = "br"

--- a/goriot.go
+++ b/goriot.go
@@ -152,6 +152,7 @@ func requestAndUnmarshal(requestURL string, v interface{}) (err error) {
 	checkRateLimiter(smallRateChan)
 	checkRateLimiter(longRateChan)
 	resp, err := http.Get(requestURL)
+	defer resp.Body.Close()
 	if err != nil {
 		return
 	}
@@ -160,7 +161,7 @@ func requestAndUnmarshal(requestURL string, v interface{}) (err error) {
 	if resp.StatusCode != http.StatusOK {
 		return RiotError{StatusCode: resp.StatusCode}
 	}
-	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return

--- a/league.go
+++ b/league.go
@@ -58,7 +58,7 @@ func LeagueBySummoner(region string, summonerID ...int64) (leagues map[int64][]L
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.5/league/by-summoner/%v?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		summonerIDstr,
 		args)
@@ -99,7 +99,7 @@ func LeagueEntryBySummoner(region string, summonerID ...int64) (leagues map[int6
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.5/league/by-summoner/%v/entry?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		summonerIDstr,
 		args)
@@ -140,7 +140,7 @@ func LeagueByTeam(region string, teamID ...string) (leagues map[string][]League,
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.5/league/by-team/%v?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		teamIDstr,
 		args)
@@ -172,7 +172,7 @@ func LeagueEntryByTeam(region string, teamID ...string) (leagues map[string][]Le
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.5/league/by-team/%v/entry?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		teamIDstr,
 		args)
@@ -198,7 +198,7 @@ func LeagueByChallenger(region string, queueType string) (league League, err err
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.5/league/challenger?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		args)
 	err = requestAndUnmarshal(url, &league)

--- a/match.go
+++ b/match.go
@@ -28,6 +28,9 @@ type Participant struct {
 	Stats         ParticipantStats    `json:"stats"`
 	TeamID        int                 `json:"teamId"`
 	Timeline      ParticipantTimeline `json:"timeline"`
+	ProfileIconID int                 `json:"profileIconId"`
+	SummonerName  string              `json:"summonerName"`
+	Bot           bool                `json:"bot"`
 }
 
 type ParticipantIdentity struct {
@@ -225,7 +228,7 @@ func MatchByMatchID(region string, includeTimeline bool, matchID int64) (match M
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.2/match/%d?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		matchID,
 		args)

--- a/match.go
+++ b/match.go
@@ -158,6 +158,7 @@ type MatchPlayer struct {
 	MatchHistoryURI string `json:"matchHistoryUri"`
 	ProfileIcon     int    `json:"profileIcon"`
 	SummonerName    string `json:"summonerName"`
+	SummonerId      int    `json:"summonerId"`
 }
 
 type BannedChampion struct {

--- a/matchhistory.go
+++ b/matchhistory.go
@@ -64,7 +64,7 @@ func MatchHistoryBySummonerID(
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.2/matchhistory/%d?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		summonerID,
 		args)

--- a/stats.go
+++ b/stats.go
@@ -103,7 +103,7 @@ func StatSummariesBySummoner(region string, summonerID int64, season string) (st
 		args = fmt.Sprintf("season=%s&", season)
 	}
 	args += "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/stats/by-summoner/%d/summary?%v", region, BaseURL, region, summonerID, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/stats/by-summoner/%d/summary?%v", region, BaseAPIURL, region, summonerID, args)
 
 	err = requestAndUnmarshal(url, &list)
 	if err != nil {
@@ -124,7 +124,7 @@ func RankedStatsBySummoner(region string, summonerID int64, season string) (stat
 		args = fmt.Sprintf("season=%s&", season)
 	}
 	args += "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/stats/by-summoner/%d/ranked?%v", region, BaseURL, region, summonerID, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.3/stats/by-summoner/%d/ranked?%v", region, BaseAPIURL, region, summonerID, args)
 
 	err = requestAndUnmarshal(url, &stats)
 	if err != nil {

--- a/summoner.go
+++ b/summoner.go
@@ -66,7 +66,7 @@ func MasteriesBySummoner(region string, summonerID ...int64) (masteries map[int6
 	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/masteries?%v", region, BaseURL, region, summonerIDstr, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/masteries?%v", region, BaseAPIURL, region, summonerIDstr, args)
 	err = requestAndUnmarshal(url, &pages)
 	if err != nil {
 		return
@@ -93,7 +93,7 @@ func RunesBySummoner(region string, summonerID ...int64) (runes map[int64][]Rune
 	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/runes?%v", region, BaseURL, region, summonerIDstr, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/runes?%v", region, BaseAPIURL, region, summonerIDstr, args)
 
 	err = requestAndUnmarshal(url, &pages)
 	if err != nil {
@@ -121,7 +121,7 @@ func SummonerByName(region string, name ...string) (summoners map[string]Summone
 	names := strURLParameter(name).String()
 	summoners = make(map[string]Summoner)
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/by-name/%v?%v", region, BaseURL, region, names, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/by-name/%v?%v", region, BaseAPIURL, region, names, args)
 	err = requestAndUnmarshal(url, &summoners)
 	if err != nil {
 		return
@@ -142,7 +142,7 @@ func SummonerByID(region string, summonerID ...int64) (summoners map[int64]Summo
 	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v?%v", region, BaseURL, region, summonerIDstr, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v?%v", region, BaseAPIURL, region, summonerIDstr, args)
 
 	err = requestAndUnmarshal(url, &summonersString)
 	if err != nil {
@@ -170,7 +170,7 @@ func SummonerNamesByID(region string, summonerID ...int64) (summoners map[int64]
 	summonerIDstr := intURLParameter(summonerID).String()
 
 	args := "api_key=" + apikey
-	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/name?%v", region, BaseURL, region, summonerIDstr, args)
+	url := fmt.Sprintf("https://%v.%v/lol/%v/v1.4/summoner/%v/name?%v", region, BaseAPIURL, region, summonerIDstr, args)
 
 	err = requestAndUnmarshal(url, &summonerNames)
 	if err != nil {

--- a/team.go
+++ b/team.go
@@ -80,7 +80,7 @@ func TeamBySummonerID(region string, summonerID ...int64) (teams map[int64][]Tea
 
 	args := "api_key=" + apikey
 	url := fmt.Sprintf("https://%v.%v/lol/%v/v2.4/team/by-summoner/%v?%v",
-		region, BaseURL, region, summonerIdStr, args)
+		region, BaseAPIURL, region, summonerIdStr, args)
 
 	err = requestAndUnmarshal(url, &preTeams)
 	if err != nil {
@@ -116,7 +116,7 @@ func TeamByTeamID(region string, teamID ...string) (teams map[string]Team, err e
 	url := fmt.Sprintf(
 		"https://%v.%v/lol/%v/v2.4/team/%v?%v",
 		region,
-		BaseURL,
+		BaseAPIURL,
 		region,
 		teamIdStr,
 		args)


### PR DESCRIPTION
This PR contains the following two endpoints from the Riot Official API. I made the syntax consistent with the rest of the package. I changed the BaseURL to BaseAPIURL and BaseObserverURL to have a descriptive difference.

[current-game-v1.0](https://developer.riotgames.com/api/methods#!/976)
[featured-games-v1.0](https://developer.riotgames.com/api/methods#!/977)

Please advise any changes to have PR merged.