### PR TITLE
Fixed "panic" in requestAndUnmarshal

### DIFF
--- a/goriot.go
+++ b/goriot.go
@@ -152,10 +152,10 @@ func requestAndUnmarshal(requestURL string, v interface{}) (err error) {
 	checkRateLimiter(smallRateChan)
 	checkRateLimiter(longRateChan)
 	resp, err := http.Get(requestURL)
-	defer resp.Body.Close()
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close()
 	checkTimeTrigger(smallRateChan)
 	checkTimeTrigger(longRateChan)
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
If the request fails a _runtime error_ occurs:

`panic: runtime error: invalid memory address or nil pointer dereference`

After some research I found the problem in a [stackoverflow thread](http://stackoverflow.com/a/16280362). This PR should fix it.
